### PR TITLE
LCW24-2 | Parse the website using beautiful soup

### DIFF
--- a/london-cocktail-week-2024.ipynb
+++ b/london-cocktail-week-2024.ipynb
@@ -37,9 +37,59 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "3143b97e-1adc-4b8e-b0f3-33db831c1084",
+   "metadata": {},
+   "source": [
+    "## The Code"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6e531aaa-fd72-46b8-aedb-9a03e2893ce2",
+   "metadata": {},
+   "source": [
+    "### Import Statements"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "8ec5c75d-a6b7-4f93-be23-50dfe1089acb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4d7b12b6-d04b-496f-888b-e8e57497b8d4",
+   "metadata": {},
+   "source": [
+    "### Parse the Website"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "f1996a7d-af4f-4230-8069-8f9082460a37",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get the PDF from the website\n",
+    "request = requests.get(\n",
+    "    'https://londoncocktailweek.com/bars/print/?collectionId=0&whatId=0&areaId=0&spiritId=0&openNow=0&search='\n",
+    ")\n",
+    "\n",
+    "# Parse the website using Beautiful Soup\n",
+    "parsed_website = BeautifulSoup(request.text, 'html.parser')"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f1996a7d-af4f-4230-8069-8f9082460a37",
+   "id": "20b9374b-b8cb-4953-ad00-d3e4112123a2",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
# [LCW24-2] | Parse the website using Beautiful Soup

## Work
Gets the request from: https://londoncocktailweek.com/bars/print/?collectionId=0&whatId=0&areaId=0&spiritId=0&openNow=0&search=. The website is then parsed using Beautiful Soup.

## Testing
- Run `jupyter-lab`.
- Run all cells.
- Add an additional cell to display `parsed_website`, which should be the HTML of the website.

[LCW24-2]: https://rheannemcintosh.atlassian.net/browse/LCW24-2?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ