### PR TITLE
LCW24-3 | Loop through the bars and save the bar details

### DIFF
--- a/london-cocktail-week-2024.ipynb
+++ b/london-cocktail-week-2024.ipynb
@@ -54,11 +54,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 4,
    "id": "8ec5c75d-a6b7-4f93-be23-50dfe1089acb",
    "metadata": {},
    "outputs": [],
    "source": [
+    "from bs4 import BeautifulSoup\n",
+    "import pandas as pd\n",
     "import requests"
    ]
   },
@@ -72,7 +74,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 7,
    "id": "f1996a7d-af4f-4230-8069-8f9082460a37",
    "metadata": {},
    "outputs": [],
@@ -87,9 +89,60 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "a331c3f9-0ab2-44ab-9e9c-b6d42018b830",
+   "metadata": {},
+   "source": [
+    "### Collate bars into a Data Frame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "15e7ae82-c63b-4805-8eba-a2e0e5822841",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create the dataframe\n",
+    "df = pd.DataFrame(columns=[\n",
+    "    'Bar Name',\n",
+    "    'Address',\n",
+    "    'Phone Number',\n",
+    "    'Description',\n",
+    "])\n",
+    "\n",
+    "# Get the list of bars\n",
+    "bars = parsed_website.find('ul').findChildren(\"li\", recursive=False)\n",
+    "\n",
+    "# Loop through each bar\n",
+    "for i, bar in enumerate(bars):\n",
+    "    # Store the bar name, address, phone number & description\n",
+    "    bar_name     = bar.find('h2', {'class': 'bar_name'}).getText()\n",
+    "    address      = bar.find('div', {'class': 'text'}).getText()\n",
+    "    phone_number = bar.find('div', {'class': 'text--padded'}).getText()\n",
+    "    description  = bar.find('p', {'class': 'text text--padded'}).getText()\n",
+    "\n",
+    "    # Save this data to the dataframe\n",
+    "    df.loc[i] = [\n",
+    "        bar_name,\n",
+    "        address,\n",
+    "        phone_number,\n",
+    "        description\n",
+    "    ]"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20b9374b-b8cb-4953-ad00-d3e4112123a2",
+   "id": "8573457d-56f5-46ec-a050-3b5714b0dd98",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7d898c8-35db-4625-a38c-59a504a268fb",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
# [LCW24-3] | Loop through the bars and save the bar details

## Work
Loop through the parsed HTML to get all of the bar names, addresses, phone numbers & a description of the bar. This should then be saved to a dataframe.

## Testing
- Run `jupyter-lab`.
- Run all of the cells.
- Add an additional cell to display `df`, which should display a list of bars.

[LCW24-3]: https://rheannemcintosh.atlassian.net/browse/LCW24-3?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ